### PR TITLE
add more robust app delete/cleanup

### DIFF
--- a/src/test/assignment_suite.js
+++ b/src/test/assignment_suite.js
@@ -73,8 +73,11 @@ describe('Assignment Test Suite', function () {
     })
   })
 
-  // Delete the app from GUI
-  it('Delete the expanded app', () => {
-    return myApps.deleteExpandedApp()
+  // Wanted to add this to after hook as framework fail safe
+  // after('Cleanup', () => {})
+  // but allure does not report mocha hooks as tests, but as steps
+  // So adding it as a test instead
+  it('Delete the App', () => {
+    return myApps.deleteAppByAppNameE2E(appName, username, password)
   })
 })

--- a/src/test/data/consumer.json
+++ b/src/test/data/consumer.json
@@ -1,4 +1,4 @@
 {
-  "consumerKey": "GXLDdDIVpM8BA7zWNQeGEka48yVs2Jyk",
-  "consumerSecret": "ojjc9HZCIigw5AMr"
+  "consumerKey": "<your app consumer key>",
+  "consumerSecret": "<your app consumer secret>"
 }

--- a/src/test/web/common.js
+++ b/src/test/web/common.js
@@ -10,11 +10,15 @@ const loginButton = '.account-menu > li:nth-child(2)'
 const modalUsername = '#edit-name'
 const modalPassword = '#edit-pass'
 const modalLogin = '#edit-submit'
+const gettingStarted = '//a[contains(text(), "Getting Started")]'
 
 // Launch the app to a path, default: '/'
-const launchApp = (basePath = '/') => {
-  return driver.url(basePath)
-}
+const launchApp = allure.createStep(
+  'Launch the app to provided url',
+  (basePath = '/') => {
+    return driver.url(basePath)
+  }
+)
 
 // Click on login and open the modal
 const openLoginModal = allure.createStep('Open the login modal', () => {
@@ -32,6 +36,20 @@ const enterCredentials = allure.createStep(
   }
 )
 
+// Check if user is logged in
+const isUserLoggedIn = allure.createStep(
+  'Check if the user is already logged in',
+  () => {
+    return driver
+      .waitForVisible(gettingStarted, waitTime)
+      .isVisible(loginButton)
+      .then((isVisible) => {
+        // if login is visible user is not logged in
+        return isVisible ? false : true
+      })
+  }
+)
+
 // Open the modal, enter credentials and click Login
 const login = allure.createStep('LogIn to app', (username, password) => {
   return openLoginModal()
@@ -43,7 +61,18 @@ const login = allure.createStep('LogIn to app', (username, password) => {
     })
 })
 
+// Log in the user if not already logged in
+const loginIfNotLoggedIn = allure.createStep(
+  'Log In the user if not already logged in',
+  (username, password) => {
+    return isUserLoggedIn().then((loggedIn) => {
+      return !loggedIn && login(username, password)
+    })
+  }
+)
+
 module.exports = {
   launchApp,
   login,
+  loginIfNotLoggedIn,
 }

--- a/src/test/web/myApps.js
+++ b/src/test/web/myApps.js
@@ -3,6 +3,7 @@
  */
 const assert = require('assert')
 const driver = require('./setup')
+const common = require('./common')
 
 const waitTime = 2000
 
@@ -92,10 +93,31 @@ const deleteExpandedApp = allure.createStep('Delete the app', () => {
   return startDeleteApp().then(() => modalDelete())
 })
 
+// Open MyApps directly through the url
+const openMyApps = allure.createStep(
+  'Open My Apps by url',
+  (username, password) => {
+    return common.launchApp('/user/me/apps').then(() => {
+      return common.loginIfNotLoggedIn(username, password)
+    })
+  }
+)
+
+// Delete the app end to end by app name
+const deleteAppByAppNameE2E = allure.createStep(
+  'Delete the app end-to-end by app name',
+  (appName, username, password) => {
+    return openMyApps(username, password)
+      .then(() => toggleAppDetails(appName))
+      .then(() => deleteExpandedApp())
+  }
+)
+
 module.exports = {
   startAddApp,
   validateAppCreatedMessage,
   toggleAppDetails,
   extractConsumerInfo,
   deleteExpandedApp,
+  deleteAppByAppNameE2E,
 }

--- a/src/test/web/web_test_suite.js
+++ b/src/test/web/web_test_suite.js
@@ -55,4 +55,15 @@ describe('Web Test Suite', function () {
   it('Delete the expanded app', () => {
     return myApps.deleteExpandedApp()
   })
+
+  // Add a fail safe to delete the app if the suite flow does not end up deleting the app
+  // wanted to use after hook here, but allure does not recognsize mocha hooks as test
+  it('Delete App if not already deleted', () => {
+    return myApps
+      .deleteAppByAppNameE2E(appName, username, password)
+      .catch((err) => {
+        // In the after hook this test should not produce failure,
+        // as it is bound to fail if app gets deleted successfully
+      })
+  })
 })


### PR DESCRIPTION
Wanted to add the delete as cleanup (part of framework), but allure does not recognize mocha hooks as tests, rather as test steps.  
So adding it as a last test, just as failsafe in web standalone test suite.
Adding the test as the final deletion step, more robust.